### PR TITLE
Oppdaterer workflows for v2

### DIFF
--- a/.github/workflows/adocs-build-and-publish-v2-production.yml
+++ b/.github/workflows/adocs-build-and-publish-v2-production.yml
@@ -3,7 +3,7 @@ name: Build adocs and publish to production
 on:
   push:
     branches:
-      - v1
+      - v2
     paths:
       - docs/**
   workflow_dispatch:
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: v1
+          ref: v2
 
       - name: Build html
         id: adocbuild

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Klikk på Issues og deretter New issue for å melde inn endringsbehov og endring
 [\- _Digitaliseringsdirektoratet / Norwegian Digitalisation Agency_](https://digdir.no/)
 
 ## Publisering
- - Gjeldende versjon av standarden vil ligge i v1-branch og blir publisert til <https://data.norge.no/specification/forvaltningsstandard-begrepskoordinering>
- - "Redaktørens utkast" (develop-branch)) vil bli publisert som GitHub pages.
+ - Gjeldende versjon av standarden blir publisert til: https://data.norge.no/specification/forvaltningsstandard-begrepskoordinering
+ - "Redaktørens utkast" blir publisert til: https://informasjonsforvaltning.github.io/forvaltningsstandard-begrepskoordinering
 
 ## Å bidra direkte
 For å bidra til utviklingen av denne standarden, må du clone den til din datamaskin og opprette en pull request.


### PR DESCRIPTION
Bommet på versjonsnummer i stad, skulle ha oppdatert workflows for v2-branch (fordi standarden er allerede i v.2.x), derfor denne strafferunden. 