### PR TITLE
chore: use reusable specification workflows

### DIFF
--- a/.github/workflows/adocs-build-and-publish-v2-production.yml
+++ b/.github/workflows/adocs-build-and-publish-v2-production.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   upload-files-to-production:
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/v2'
     name: Upload specification to static-rdf-server
     uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
     with:

--- a/.github/workflows/adocs-build-and-publish-v2-production.yml
+++ b/.github/workflows/adocs-build-and-publish-v2-production.yml
@@ -1,5 +1,8 @@
 name: Build adocs and publish to production
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -8,54 +11,28 @@ on:
       - docs/**
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: v2
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/forvaltningsstandard-begrepskoordinering.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload files to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
-        id: upload-files
-        with:
-          ontology-type: "specification"
-          ontology: "forvaltningsstandard-begrepskoordinering"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/forvaltningsstandard-begrepskoordinering.pdf application/pdf nb files/forvaltningsstandard-begrepskoordinering.pdf
-            docs/images/Digdir.png image/png nb images/Digdir.png
-            docs/images/avlopsvann1.png image/png nb images/avlopsvann1.png
-            docs/images/avlopsvann2.png image/png nb images/avlopsvann2.png
-            docs/images/forarbeid.png image/png nb images/forarbeid.png
-            docs/images/heltidsstudent.png image/png nb images/heltidsstudent.png
-            docs/images/prosessmodell.png image/png nb images/prosessmodell.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v2
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/forvaltningsstandard-begrepskoordinering.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      files: |
+        docs/index.html text/html nb
+        docs/files/forvaltningsstandard-begrepskoordinering.pdf application/pdf nb files/forvaltningsstandard-begrepskoordinering.pdf
+        docs/images/Digdir.png image/png nb images/Digdir.png
+        docs/images/avlopsvann1.png image/png nb images/avlopsvann1.png
+        docs/images/avlopsvann2.png image/png nb images/avlopsvann2.png
+        docs/images/forarbeid.png image/png nb images/forarbeid.png
+        docs/images/heltidsstudent.png image/png nb images/heltidsstudent.png
+        docs/images/prosessmodell.png image/png nb images/prosessmodell.png
+      host: https://data.norge.no
+      ontology: forvaltningsstandard-begrepskoordinering
+      ontology-type: specification
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/adocs-build-publish-develop.yml
+++ b/.github/workflows/adocs-build-publish-develop.yml
@@ -1,5 +1,8 @@
 name: Build adocs and publish develop to Github pages
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:
@@ -8,42 +11,17 @@ on:
       - docs/**
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pages: write
-
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
+  build-adocs:
     name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/forvaltningsstandard-begrepskoordinering.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/forvaltningsstandard-begrepskoordinering.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      publish_branch: gh-pages
+      publish_dir: ./docs
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/adocs-build-publish-develop.yml
+++ b/.github/workflows/adocs-build-publish-develop.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build-adocs:
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/develop'
     name: asciidoctor build
     uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 index.html
 *.pdf
 *.epub
+.idea


### PR DESCRIPTION
# Summary 

- Migrate develop GitHub Pages workflow to call specification-github-pages.yaml@main
- Migrate v2 production workflow to call specification-upload-files.yaml@main
- Guard workflow_dispatch on both workflows so only the deploy branch can publish
- Add .idea to .gitignore

Closes #40
Closes #42

Notes:
- #40: migration removes all 8 unpinned third-party action references from this repo; the reusable workflows pin checkout, asciidoctor, peaceiris and upload-files to SHAs internally.
- #42: the publish-step `if:` from the issue can't apply inside a reusable workflow, so the guard is at job level. Trade-off: dispatch from a non-deploy branch is fully skipped (no separate build-only run, since the reusable job couples build and publish).